### PR TITLE
Adding support for schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IDE
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ pipx install git+https://github.com/MeltanoLabs/tap-universal-file.git
 | file_path                    | True     | None    | The path to obtain files from. Example: `/foo/bar`. Or, for `protocol==s3`, use `s3-bucket-name` instead. |
 | file_regex                  | False    | None    | A regex pattern to only include certain files. Example: `.*\.csv`. |
 | file_type                   | False    | delimited | Must be one of `delimited`, `jsonl`, or `avro`. Indicates the type of file to sync, where `delimited` is for CSV/TSV files and similar. Note that *all* files will be read as that type, regardless of file extension. To only read from files with a matching file extension, appropriately configure `file_regex`. |
+| schema                      | False    | None    | The declarative schema to use for the stream. It can be the schema itself or a path to a json file containing the schema, see [example](https://github.com/meltano/hub/blob/c4b541bbdc36b1b6efffa1eb6022367d8de43e3a/schemas/plugin_definitions/hub_metadata.schema.json). If not provided, the schema will be inferred. |
 | compression                 | False    | detect  | The encoding used to decompress data. Must be one of `none`, `zip`, `bz2`, `gzip`, `lzma`, `xz`, or `detect`. If set to `none` or any encoding, that setting will be applied to *all* files, regardless of file extension. If set to `detect`, encodings will be applied based on file extension. |
 | additional_info             | False    |       1 | If `True`, each row in tap's output will have three additional columns: `_sdc_file_name`, `_sdc_line_number`, and `_sdc_last_modified`. If `False`, these columns will not be present. Incremental replication requires `additional_info==True`. |
 | start_date                  | False    | None    | Used in place of state. Files that were last modified before the `start_date` wwill not be synced. |
@@ -60,6 +61,7 @@ tap is available by running:
 ```bash
 tap-universal-file --about
 ```
+
 
 ### Regular Expressions
 

--- a/tap_universal_file/client.py
+++ b/tap_universal_file/client.py
@@ -86,6 +86,11 @@ class FileStream(Stream):
             A schema constructed using the get_properties() method of whichever stream
             is currently in use.
         """
+        if hasattr(self, "_schema"):
+            self.logger.debug(f"Using schema from config: {self._schema}")
+            return self._schema
+
+        self.logger.debug(f"No schema found in config, creating schema...")
         properties = self.get_properties()
         additional_info = self.config["additional_info"]
         if additional_info:
@@ -146,7 +151,7 @@ class FileStream(Stream):
         raise NotImplementedError(msg)
 
     def get_compression(self, file: str) -> str | None:
-        """Determines what compression encoding is appropraite for a given file.
+        """Determines what compression encoding is appropriate for a given file.
 
         Args:
             file: The file to determine the encoding of.

--- a/tap_universal_file/files.py
+++ b/tap_universal_file/files.py
@@ -49,7 +49,7 @@ class FilesystemManager:
             return fsspec.filesystem("file")
 
         if caching_strategy == "once":
-            # Creaing a filecache without specifying cache_storage location will cause
+            # Creating a filecache without specifying cache_storage location will cause
             # the cache to be discarded after the filesystem is closed.
             # Docs: https://filesystem-spec.readthedocs.io/en/latest/features.html#caching-files-locally
             return fsspec.filesystem(
@@ -65,7 +65,7 @@ class FilesystemManager:
                 cache_storage=tempfile.gettempdir(),
             )
         if caching_strategy == "none":
-            # When caching is not used, the protocol's arguemnts have to be
+            # When caching is not used, the protocol's arguments have to be
             # star-unpacked because fsspec.filesystem accepts them directly instead of
             # as a dictionary.
             return fsspec.filesystem(
@@ -181,7 +181,7 @@ class FilesystemManager:
                 implementation and when unpacked (**) for a direct implementation.
 
         Returns:
-            A dictionary containing fsspec arguements.
+            A dictionary containing fsspec arguments.
         """
         if self.protocol == "s3":
             if self.config["s3_anonymous_connection"]:

--- a/tap_universal_file/streams.py
+++ b/tap_universal_file/streams.py
@@ -67,7 +67,7 @@ class DelimitedStream(FileStream):
     def _get_readers(
         self,
     ) -> Generator[tuple[ModifiedDictReader, str, str], None, None]:
-        """Gets reader objects and associated meta data.
+        """Gets reader objects and associated metadata.
 
         Raises:
             RuntimeError: If improper configuration is supplied.
@@ -339,7 +339,7 @@ class AvroStream(FileStream):
         """Retrive all rows from all Avro files.
 
         Yields:
-            A dictionary containing information about a row in a Avro file.
+            A dictionary containing information about a row in an Avro file.
         """
         for reader, file_name, last_modified in self._get_readers():
             self.logger.info("Starting sync of %s.", file_name)
@@ -461,7 +461,7 @@ class AvroStream(FileStream):
     def _get_readers(
         self,
     ) -> Generator[tuple[avro.datafile.DataFileReader, str, str], None, None]:
-        """Gets reader objects and associated meta data.
+        """Gets reader objects and associated metadata.
 
         Yields:
             A tuple of (avro.datafile.DataFileReader, file_name, last_modified).

--- a/tap_universal_file/tap.py
+++ b/tap_universal_file/tap.py
@@ -91,6 +91,16 @@ class TapUniversalFile(Tap):
             ),
         ),
         th.Property(
+            "schema",
+            th.StringType,
+            description=(
+                "The declarative schema to use for the stream. It can be the schema "
+                "itself or a path to a json file containing the schema. If not "
+                "provided, the schema will be inferred from the data following "
+                "the coercion strategy."
+            ),
+        ),
+        th.Property(
             "compression",
             th.StringType,
             allowed_values=(
@@ -301,12 +311,13 @@ class TapUniversalFile(Tap):
         """
         name = self.config["stream_name"]
         file_type = self.config["file_type"]
+        schema = self.config.get("schema", None)
         if file_type == "delimited":
-            return [streams.DelimitedStream(self, name=name)]
+            return [streams.DelimitedStream(self, name=name, schema=schema)]
         if file_type == "jsonl":
-            return [streams.JSONLStream(self, name=name)]
+            return [streams.JSONLStream(self, name=name, schema=schema)]
         if file_type == "avro":
-            return [streams.AvroStream(self, name=name)]
+            return [streams.AvroStream(self, name=name, schema=schema)]
         if file_type in {"csv", "tsv", "txt"}:
             msg = f"'{file_type}' is not a valid file_type. Did you mean 'delimited'?"
             raise ValueError(msg)


### PR DESCRIPTION
### Context
We need to read JSONL files with complex structs, including many data types like array, object, datetime, string, etc...
The current implementation offers `jsonl_type_coercion_strategy` to decide how the tap is going to infer the schema. The problem is that none of the coercion strategies works for our use case. Besides that, the `jsonl_sampling_strategy` only supports `first` which does not work for our use case.

This PR implements a possible solution, by adding a new parameter named schema. This parameter would be parsed by Meltano SDK, [see here](https://github.com/meltano/sdk/blob/b1b97b06231378f95c0530cb5fbd854ad67624b8/singer_sdk/streams/core.py#L147-L170). 

If the user decides to specify a fixed schema, the tap does not need to create the schema dynamically, ignoring the coercion strategy.

### Changes
- Adding a new parameter to specify schema
- Updating documentation
- Fixing typos
- Adding IDE files in .gitignore

